### PR TITLE
ndvi2gif v1.3.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "ndvi2gif" %}
-{% set version = "1.2.2" %}
+{% set version = "1.3.0" %}
 {% set python_min = "3.8" %}
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 2f73a6a1780c06d5f70f63e577434a6ed0065f4ac4d70c3820059ded73b1cb8e
+  sha256: f2940df8553b8c1119519c2bb6b245b99dade3e893d16882aa6f88e8422b3d35
 
 build:
   noarch: python
@@ -35,6 +35,7 @@ requirements:
     - requests
     - geopandas
     - fiona
+    - rasterio
     - pycrs
     - deims >=4.0
     - statsmodels >=0.13


### PR DESCRIPTION
Update ndvi2gif to v1.3.0.

Changes:
- Bump version `1.2.2` → `1.3.0`
- Update `sha256` for the new PyPI sdist
- Add `rasterio` run dependency (new in v1.3.0, required by `SpatialPhenologyAnalyzer`)

Checklist:
- [x] Used a personal fork of the feedstock to propose changes
- [x] Bumped the build number (reset to 0 for new version)
- [x] Re-rendered with the latest conda-smithy (not needed for a simple version bump)
- [x] Ensured the license file is being packaged