### PR TITLE
Update to v1.3.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "ndvi2gif" %}
-{% set version = "1.3.0" %}
+{% set version = "1.3.1" %}
 {% set python_min = "3.8" %}
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: f2940df8553b8c1119519c2bb6b245b99dade3e893d16882aa6f88e8422b3d35
+  sha256: a9c468c3df21e0b0e3c841ed37f69d0ac46b57927deb93ae350ca2a37a5e9e85
 
 build:
   noarch: python


### PR DESCRIPTION
Updates ndvi2gif to v1.3.1 (bugfix release: per-sensor status output is now printed only for the selected satellite; JOSS review).

- `version` 1.3.0 → 1.3.1
- `sha256` updated for the new PyPI sdist
- Build number reset to 0 (new version)
- No dependency changes (`rasterio` already added in v1.3.0)

Checklist:
- [x] Used a personal fork of the feedstock to propose changes
- [x] Bumped the build number (reset to 0 for the new version)
- [x] Ensured the license file is being packaged