### PR TITLE
Update to 1.5.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,5 @@
 {% set name = "ndvi2gif" %}
 {% set version = "1.5.0" %}
-{% set python_min = "3.8" %}
 
 package:
   name: {{ name|lower }}
@@ -17,7 +16,7 @@ build:
 
 requirements:
   host:
-    - python >={{ python_min }}
+    - python {{ python_min }}
     - pip
     - setuptools
   run:
@@ -27,7 +26,7 @@ requirements:
     - numpy >=1.24
     - pandas
     - scipy
-    - matplotlib
+    - matplotlib-base
     - seaborn
     - pillow
     - imageio
@@ -49,7 +48,7 @@ test:
     - ndvi2gif.clasification
     - ndvi2gif.hydroperiod
   requires:
-    - python >={{ python_min }}
+    - python {{ python_min }}
 
 about:
   home: https://github.com/Digdgeo/Ndvi2Gif

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "ndvi2gif" %}
-{% set version = "1.4.0" %}
+{% set version = "1.5.0" %}
 {% set python_min = "3.8" %}
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 82bfa4f2180f7b47abc26fbb7256c1b9b2ba282555814068676907a0ea47be9b
+  sha256: b48644e5d30af345cfa1f4b0a9493dc7a935895122f844c3d5a79dccd5e766c7
 
 build:
   noarch: python
@@ -36,7 +36,6 @@ requirements:
     - geopandas
     - fiona
     - rasterio
-    - pycrs
     - deims >=4.0
     - statsmodels >=0.13
     - scikit-learn >=1.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,6 +43,7 @@ requirements:
 test:
   imports:
     - ndvi2gif
+    - ndvi2gif.ndvi2gif
     - ndvi2gif.s1_ard
     - ndvi2gif.timeseries
     - ndvi2gif.clasification


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Updates to 1.5.0: raw reflectance bands as selectable indices, `key='count'`, and fixes in `SpatialTrendAnalyzer`. Full notes:
https://github.com/Digdgeo/Ndvi2Gif/releases/tag/v1.5.0

Recipe changes beyond version and sha256:

- Drops `pycrs` from `run:`. It was declared in `setup.cfg` but never imported anywhere in the package, and it is gone upstream in 1.5.0. `fiona` stays,  geopandas uses it as a file engine.
- Adds `ndvi2gif.ndvi2gif` to the test imports. It is already covered by the bare `ndvi2gif` import, since `__init__.py` pulls it in, but listing it keeps the check if the layout ever changes.